### PR TITLE
Add truncate class to invite code button text

### DIFF
--- a/src/components/pds-info.tsx
+++ b/src/components/pds-info.tsx
@@ -60,7 +60,7 @@ function CreateInviteCodeButton() {
         <div className="loading loading-spinner loading-sm absolute"></div>
       )}
       <span className="i-lucide-ticket size-4"></span>
-      <span className={cn(loading && "opacity-0")}>
+      <span className={cn("truncate", loading && "opacity-0")}>
         {t("pds-info.buttons.create-invite-code")}
       </span>
     </div>


### PR DESCRIPTION
This aligns the invite code button text styling with other PDS action buttons by adding the 'truncate' class to prevent text overflow.

Fixes #21

Generated with [Claude Code](https://claude.ai/code)