### PR TITLE
Add password storage preference checkbox to login form

### DIFF
--- a/src/atoms/pds.ts
+++ b/src/atoms/pds.ts
@@ -5,6 +5,9 @@ import { requiredSessionAtom } from "./session";
 
 export const pdsAtom = atom((get) => {
   const session = get(requiredSessionAtom);
+  if (!session.adminPassword) {
+    throw new Error("Password not saved. Please log in again.");
+  }
   return new PDS(session);
 });
 

--- a/src/atoms/session.ts
+++ b/src/atoms/session.ts
@@ -4,17 +4,32 @@ import { atomWithStorage } from "jotai/utils";
 type Session = {
   service: string;
   adminPassword: string;
+  savePassword?: boolean;
 };
 
 const baseAtom = atomWithStorage<Session | null>("session", null, undefined, {
   getOnInit: true,
 });
 
-export const useSetSession = () => useSetAtom(baseAtom);
+export const useSetSession = () => {
+  const setSessionAtom = useSetAtom(baseAtom);
+  return (session: Session) => {
+    if (session.savePassword === false) {
+      const sessionWithoutPassword = {
+        service: session.service,
+        adminPassword: "",
+        savePassword: false,
+      };
+      setSessionAtom(sessionWithoutPassword);
+    } else {
+      setSessionAtom(session);
+    }
+  };
+};
 
 export const useLogout = () => {
-  const setSession = useSetSession();
-  return () => setSession(null);
+  const setSessionAtom = useSetAtom(baseAtom);
+  return () => setSessionAtom(null);
 };
 
 export const useIsLoggedIn = () => {
@@ -32,4 +47,15 @@ export const requiredSessionAtom = atom((get) => {
 
 export const useSession = () => {
   return useAtomValue(requiredSessionAtom);
+};
+
+export const useSessionWithPassword = () => {
+  const session = useAtomValue(baseAtom);
+  if (!session) {
+    throw new Error("Session not found");
+  }
+  if (!session.adminPassword) {
+    throw new Error("Password not saved. Please log in again.");
+  }
+  return session;
 };

--- a/src/components/signin-form.tsx
+++ b/src/components/signin-form.tsx
@@ -10,6 +10,7 @@ import { Button } from "./button";
 const initialForm = {
   service: "",
   adminPassword: "",
+  savePassword: true,
   loading: false,
   error: "",
 };
@@ -27,6 +28,9 @@ const useForm = () => {
     },
     setAdminPassword: (adminPassword: string) => {
       setFormState((prev) => ({ ...prev, adminPassword }));
+    },
+    setSavePassword: (savePassword: boolean) => {
+      setFormState((prev) => ({ ...prev, savePassword }));
     },
     setLoading: (loading: boolean) => {
       setFormState((prev) => ({ ...prev, loading }));
@@ -99,6 +103,18 @@ export function SigninForm() {
             onChange={(e) => form.setAdminPassword(e.target.value)}
             data-testid="admin-password-input"
           />
+        </div>
+        <div className="form-control">
+          <label className="label cursor-pointer">
+            <span className="label-text">{t("signin.save-password")}</span>
+            <input
+              type="checkbox"
+              className="checkbox"
+              checked={form.state.savePassword}
+              onChange={(e) => form.setSavePassword(e.target.checked)}
+              data-testid="save-password-checkbox"
+            />
+          </label>
         </div>
         <div className="card-actions mt-4 justify-end">
           <Button

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -71,6 +71,7 @@
     "title": "Sign in to PDS",
     "pds-url": "PDS URL",
     "admin-password": "Admin Password",
+    "save-password": "Save password to localStorage",
     "button": "Sign In",
     "toast": "Sign in successfully"
   }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -71,6 +71,7 @@
     "title": "PDSにサインイン",
     "pds-url": "PDSのURL",
     "admin-password": "管理者パスワード",
+    "save-password": "パスワードをLocalStorageに保存する",
     "button": "サインイン",
     "toast": "正常にサインインしました"
   }


### PR DESCRIPTION
Add password storage preference checkbox to login form

This implements the feature requested in issue #23 to allow users to choose whether to save their password to localStorage during login.

## Changes
- Add translation keys for save password option in both English and Japanese
- Add checkbox to sign-in form to allow users to choose whether to save password
- Update session atom to conditionally store password based on user preference
- Update PDS atom to handle sessions without saved passwords
- When password is not saved, users will need to log in again for operations

Fixes #23

Generated with [Claude Code](https://claude.ai/code)