### PR TITLE
feat: アカウント作成フォームをconform-to/reactでリファクタリング

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "dependencies": {
     "@atcute/client": "^4.0.0",
+    "@conform-to/react": "^2.5.1",
+    "@conform-to/zod": "^2.5.1",
     "@tailwindcss/vite": "^4.1.6",
     "clsx": "^2.1.1",
     "i18next": "^25.2.1",
@@ -30,7 +32,8 @@
     "react-dom": "^19.1.0",
     "react-i18next": "^15.5.2",
     "tailwind-merge": "^3.3.0",
-    "tailwindcss": "^4.1.6"
+    "tailwindcss": "^4.1.6",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@atcute/atproto": "^3.0.0",

--- a/src/components/modal/body/create-account.tsx
+++ b/src/components/modal/body/create-account.tsx
@@ -1,24 +1,38 @@
-import { type FormEvent, useState } from "react";
+import { useForm } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod";
+import { type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
+import { z } from "zod";
 
 import { usePDS, usePDSHostname } from "../../../atoms/pds";
 import { Button } from "../../button";
 import { useModalHandler } from "../hooks";
 
+const createAccountSchema = z.object({
+  handle: z.string().min(1, "Handle is required").includes(".", "Handle must contain a dot"),
+  email: z.string().email("Invalid email address"),
+  password: z.string().min(1, "Password is required"),
+});
+
 export function CreateAccountModalBody() {
   const { t } = useTranslation();
   const pds = usePDS();
   const pdsHostname = usePDSHostname();
-  const [handle, setHandle] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+
+  const [form, fields] = useForm({
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: createAccountSchema });
+    },
+    shouldValidate: "onBlur",
+    shouldRevalidate: "onInput",
+  });
 
   const { loading, handler } = useModalHandler({
     fn: () =>
       pds.createAccount({
-        handle: handle as `${string}.${string}`,
-        email,
-        password,
+        handle: fields.handle.value as `${string}.${string}`,
+        email: fields.email.value!,
+        password: fields.password.value!,
       }),
     toastMessage: t("modal.create-account.toast"),
     shouldReloadRepos: true,
@@ -26,10 +40,13 @@ export function CreateAccountModalBody() {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    await handler();
-    setHandle("");
-    setEmail("");
-    setPassword("");
+    const formData = new FormData(e.currentTarget);
+    const submission = parseWithZod(formData, { schema: createAccountSchema });
+    
+    if (submission.status === "success") {
+      await handler();
+      form.reset();
+    }
   };
 
   return (
@@ -37,48 +54,64 @@ export function CreateAccountModalBody() {
       className="flex flex-col items-center gap-4"
       onSubmit={handleSubmit}
       data-testid="create-account-form"
+      {...form.props}
     >
       <span className="i-lucide-user-plus size-12"></span>
       <p className="text-center">{t("modal.create-account.title")}</p>
-      <label className="input input-bordered flex items-center gap-2">
-        <span className="i-lucide-at-sign size-4"></span>
-        <input
-          type="text"
-          placeholder={`example.${pdsHostname}`}
-          required
-          autoComplete="username"
-          value={handle}
-          onChange={(e) => setHandle(e.target.value)}
-          className="grow"
-          data-testid="create-account-handle-input"
-        />
-      </label>
-      <label className="input input-bordered flex items-center gap-2">
-        <span className="i-lucide-mail size-4"></span>
-        <input
-          type="email"
-          placeholder={t("modal.create-account.placeholder.email")}
-          required
-          autoComplete="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="grow"
-          data-testid="create-account-email-input"
-        />
-      </label>
-      <label className="input input-bordered flex items-center gap-2">
-        <span className="i-lucide-lock size-4"></span>
-        <input
-          type="password"
-          placeholder={t("modal.create-account.placeholder.password")}
-          required
-          autoComplete="new-password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="grow"
-          data-testid="create-account-password-input"
-        />
-      </label>
+      <div className="flex flex-col gap-1">
+        <label className="input input-bordered flex items-center gap-2">
+          <span className="i-lucide-at-sign size-4"></span>
+          <input
+            type="text"
+            placeholder={`example.${pdsHostname}`}
+            autoComplete="username"
+            className="grow"
+            data-testid="create-account-handle-input"
+            {...fields.handle.props}
+          />
+        </label>
+        {fields.handle.errors && (
+          <div className="text-sm text-error">
+            {fields.handle.errors.join(", ")}
+          </div>
+        )}
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="input input-bordered flex items-center gap-2">
+          <span className="i-lucide-mail size-4"></span>
+          <input
+            type="email"
+            placeholder={t("modal.create-account.placeholder.email")}
+            autoComplete="email"
+            className="grow"
+            data-testid="create-account-email-input"
+            {...fields.email.props}
+          />
+        </label>
+        {fields.email.errors && (
+          <div className="text-sm text-error">
+            {fields.email.errors.join(", ")}
+          </div>
+        )}
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="input input-bordered flex items-center gap-2">
+          <span className="i-lucide-lock size-4"></span>
+          <input
+            type="password"
+            placeholder={t("modal.create-account.placeholder.password")}
+            autoComplete="new-password"
+            className="grow"
+            data-testid="create-account-password-input"
+            {...fields.password.props}
+          />
+        </label>
+        {fields.password.errors && (
+          <div className="text-sm text-error">
+            {fields.password.errors.join(", ")}
+          </div>
+        )}
+      </div>
       <Button
         type="submit"
         className="btn btn-primary relative"


### PR DESCRIPTION
✨ アカウント作成フォームのconform-to/reactリファクタリング

## 変更内容
- `@conform-to/react`、`@conform-to/zod`、`zod`の依存関係を追加
- zodスキーマによるバリデーション機能を実装
- onBlur/onInputでのリアルタイムバリデーション
- エラーメッセージの表示機能を追加
- フォームリセット機能を実装
- 既存のdata-testid属性を維持してe2eテストとの互換性を保持

## 技術的な改善点
- より宣言的なフォーム管理
- 型安全なバリデーション
- ユーザーエクスペリエンスの向上（リアルタイムフィードバック）
- より保守しやすいコード構造

Closes #25

Generated with [Claude Code](https://claude.ai/code)