### PR TITLE
Add storage preference option to login form

### DIFF
--- a/src/components/signin-form.tsx
+++ b/src/components/signin-form.tsx
@@ -1,7 +1,11 @@
 import { type FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useSetSession } from "../atoms/session";
+import {
+  useRememberLogin,
+  useSetRememberLogin,
+  useSetSession,
+} from "../atoms/session";
 import { useToast } from "../atoms/toast";
 import { PDS } from "../utils/pds";
 import { ErrorAlert } from "./alert-message";
@@ -50,6 +54,8 @@ export function SigninForm() {
   const form = useForm();
   const setSession = useSetSession();
   const toast = useToast();
+  const rememberLogin = useRememberLogin();
+  const setRememberLogin = useSetRememberLogin();
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -99,6 +105,18 @@ export function SigninForm() {
             onChange={(e) => form.setAdminPassword(e.target.value)}
             data-testid="admin-password-input"
           />
+        </div>
+        <div className="form-control w-full">
+          <label className="label cursor-pointer">
+            <span className="label-text">{t("signin.remember-login")}</span>
+            <input
+              type="checkbox"
+              className="checkbox"
+              checked={rememberLogin}
+              onChange={(e) => setRememberLogin(e.target.checked)}
+              data-testid="remember-login-checkbox"
+            />
+          </label>
         </div>
         <div className="card-actions mt-4 justify-end">
           <Button

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -71,6 +71,7 @@
     "title": "Sign in to PDS",
     "pds-url": "PDS URL",
     "admin-password": "Admin Password",
+    "remember-login": "Save login info to localStorage",
     "button": "Sign In",
     "toast": "Sign in successfully"
   }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -71,6 +71,7 @@
     "title": "PDSにサインイン",
     "pds-url": "PDSのURL",
     "admin-password": "管理者パスワード",
+    "remember-login": "ログイン情報をLocalStorageに保存する",
     "button": "サインイン",
     "toast": "正常にサインインしました"
   }


### PR DESCRIPTION
Add storage preference option to login form

This implements the feature requested in issue #23 to allow users to choose whether to save their login information to localStorage at all.

## Changes
- Split session management into persistent (localStorage) and session-only atoms
- Add checkbox to control whether login info is saved to localStorage
- When unchecked, all data is stored in memory only (session-only)
- Add translations for storage preference in English and Japanese
- Default to saving to localStorage for backwards compatibility

Fixes #23

Generated with [Claude Code](https://claude.ai/code)