### PR TITLE
fix: close language dropdown after selection

### DIFF
--- a/src/components/module/header.tsx
+++ b/src/components/module/header.tsx
@@ -1,4 +1,3 @@
-import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "../../utils/cn";
@@ -9,17 +8,17 @@ type LanguageSwitcherProps = {
 
 function LanguageSwitcher({ className }: LanguageSwitcherProps) {
   const { i18n } = useTranslation();
-  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const handleLanguageChange = async (language: string) => {
     await i18n.changeLanguage(language);
-    dropdownRef.current?.blur();
+    if (document.activeElement) {
+      (document.activeElement as HTMLElement).blur();
+    }
   };
 
   return (
     <div className={cn("dropdown dropdown-end", className)}>
       <div
-        ref={dropdownRef}
         tabIndex={0}
         role="button"
         className="btn btn-square btn-ghost shadow"

--- a/src/components/module/header.tsx
+++ b/src/components/module/header.tsx
@@ -11,8 +11,8 @@ function LanguageSwitcher({ className }: LanguageSwitcherProps) {
   const { i18n } = useTranslation();
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const handleLanguageChange = (language: string) => {
-    void i18n.changeLanguage(language);
+  const handleLanguageChange = async (language: string) => {
+    await i18n.changeLanguage(language);
     dropdownRef.current?.blur();
   };
 

--- a/src/components/module/header.tsx
+++ b/src/components/module/header.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "../../utils/cn";
@@ -8,9 +9,17 @@ type LanguageSwitcherProps = {
 
 function LanguageSwitcher({ className }: LanguageSwitcherProps) {
   const { i18n } = useTranslation();
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const handleLanguageChange = (language: string) => {
+    void i18n.changeLanguage(language);
+    dropdownRef.current?.blur();
+  };
+
   return (
     <div className={cn("dropdown dropdown-end", className)}>
       <div
+        ref={dropdownRef}
         tabIndex={0}
         role="button"
         className="btn btn-square btn-ghost shadow"
@@ -24,7 +33,7 @@ function LanguageSwitcher({ className }: LanguageSwitcherProps) {
         <li>
           <a
             className="btn btn-ghost h-12"
-            onClick={() => i18n.changeLanguage("en")}
+            onClick={() => handleLanguageChange("en")}
           >
             English
           </a>
@@ -32,7 +41,7 @@ function LanguageSwitcher({ className }: LanguageSwitcherProps) {
         <li>
           <a
             className="btn btn-ghost h-12"
-            onClick={() => i18n.changeLanguage("ja")}
+            onClick={() => handleLanguageChange("ja")}
           >
             日本語
           </a>


### PR DESCRIPTION
Fixes #31

This PR implements auto-close functionality for the language selection dropdown. When users click on "English" or "日本語", the dropdown now automatically closes after the language change, improving the user experience.

## Changes
- Added React useRef to track dropdown element
- Created handleLanguageChange function that combines language change with dropdown close
- Used blur() method to close DaisyUI dropdown after selection
- Fixed ESLint warning by using void operator for promise handling

Generated with [Claude Code](https://claude.ai/code)